### PR TITLE
Fetch multiple Jira issues per message

### DIFF
--- a/src/jirabot.coffee
+++ b/src/jirabot.coffee
@@ -22,7 +22,6 @@ RegExp::execAll = (string) ->
   matches = []
   @lastIndex = 0
   while match = @exec string
-    console.log(match)
     matches.push(match)
   return matches
 
@@ -49,7 +48,6 @@ module.exports = (robot) ->
     matchAllRegexp = /\b(([A-Za-z]+)-[\d]+)\b/gi
 
     for match in matchAllRegexp.execAll(msg.message.text)
-      console.log(match)
       msg.match = match
       getIssues(msg)
 

--- a/src/jirabot.coffee
+++ b/src/jirabot.coffee
@@ -18,6 +18,14 @@
 # Author:
 #   hxnizamani
 
+RegExp::execAll = (string) ->
+  matches = []
+  @lastIndex = 0
+  while match = @exec string
+    console.log(match)
+    matches.push(match)
+  return matches
+
 module.exports = (robot) ->
   cache = []
 
@@ -37,7 +45,13 @@ module.exports = (robot) ->
   robot.hear /.*\b(([A-Za-z]+)-[\d]+)\b.*/, (msg) ->
     # ignore if the user exists in 'jiraIgnoreUsers'
     return if msg.message.user.name.match(new RegExp(jiraIgnoreUsers, "gi"))
-    getIssues(msg)
+
+    matchAllRegexp = /\b(([A-Za-z]+)-[\d]+)\b/gi
+
+    for match in matchAllRegexp.execAll(msg.message.text)
+      console.log(match)
+      msg.match = match
+      getIssues(msg)
 
   getIssues = (msg) ->
     try

--- a/src/jirabot.coffee
+++ b/src/jirabot.coffee
@@ -47,7 +47,14 @@ module.exports = (robot) ->
 
     matchAllRegexp = /\b(([A-Za-z]+)-[\d]+)\b/gi
 
+    # used for filtering out duplicates
+    alreadySent = []
+
     for match in matchAllRegexp.execAll(msg.message.text)
+      ticket = match[1].toUpperCase()
+      if alreadySent.indexOf(ticket) != -1
+        continue
+      alreadySent.push(ticket)
       msg.match = match
       getIssues(msg)
 


### PR DESCRIPTION
This fixes a bug where only a single JIRA issue would be show for every
message which the bot hears. Even though it is perfectly possible for
people to mention more than one issue in their messages.